### PR TITLE
Add JWT bearer authentication to OpenAPI config

### DIFF
--- a/src/main/java/com/fleetmanagement/config/OpenApiConfig.java
+++ b/src/main/java/com/fleetmanagement/config/OpenApiConfig.java
@@ -1,21 +1,33 @@
 package com.fleetmanagement.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
 
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
-            .info(new Info()
-                .title("Fleet & Logistics Management API")
-                .version("1.0")
-                .description("Backend API for fleet management system"));
+                .info(new Info()
+                        .title("Fleet & Logistics Management API")
+                        .version("1.0")
+                        .description("Backend API for fleet management system"))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components().addSecuritySchemes(
+                        SECURITY_SCHEME_NAME,
+                        new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                ));
     }
 }
-


### PR DESCRIPTION
Configured OpenAPI to include a bearerAuth security scheme using JWT. This enables API documentation to reflect authentication requirements for secured endpoints.